### PR TITLE
Update rasterize_cuda_kernel.cu: replace and with &&

### DIFF
--- a/neural_renderer/cuda/rasterize_cuda_kernel.cu
+++ b/neural_renderer/cuda/rasterize_cuda_kernel.cu
@@ -6,7 +6,7 @@
 
 
 // for the older gpus atomicAdd with double arguments does not exist
-#if  __CUDA_ARCH__ < 600 and defined(__CUDA_ARCH__)
+#if  __CUDA_ARCH__ < 600 && defined(__CUDA_ARCH__)
 static __inline__ __device__ double atomicAdd(double* address, double val) {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;


### PR DESCRIPTION
and is not recognised by nvcc 11.8 toolkit .
as a result, nvcc complains of function atomicAdd declared twice

![image](https://github.com/user-attachments/assets/b499023b-7c19-494c-8dc3-32834ac93e3a)
